### PR TITLE
Allow publish workflow to accept a short SHA as ref

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git ref (branch, tag or SHA) to publish from'
+        description: 'Git ref to publish from — branch, tag, or commit SHA (short SHAs work too)'
         required: true
         default: 'main'
       dry_run:
@@ -35,6 +35,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          # Full history: actions/checkout resolves a *short* SHA only if the object is already
+          # local. With the default shallow fetch it treats the input as a branch/tag pattern
+          # (refs/heads/<ref>*) and dies with an opaque "git failed with exit code 1".
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
Hit while publishing 1.1.0: dispatching the workflow with `ref=39b26ab` failed inside `actions/checkout` with a bare `The process '/usr/bin/git' failed with exit code 1`.

Cause: with the default shallow fetch, `actions/checkout` can't resolve a short SHA, so it falls back to treating the input as a branch/tag pattern (`+refs/heads/39b26ab*`), matches nothing, and fails — before any publish step runs. Re-dispatching with the full 40-char SHA worked, and 1.1.0/1.2.0 are both on npm.

`fetch-depth: 0` makes branch, tag and short/full SHA all resolve. Also clarifies the input description.