### PR TITLE
Scope bundled pdf.js CSS to prevent restyling host applications (1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `teamsync-pdf-viewer` are documented here.
 
+## [1.2.1] — 2026-09-01
+
+### Fixed
+- **The stylesheet no longer restyles the host application.** `dist/style.css` bundles
+  `pdfjs-dist/web/pdf_viewer.css`, ~900 selectors written for pdf.js's own standalone viewer —
+  including bare generic class names such as `.sidebar`, `.dialog`, `.toggle-button`,
+  `.closeButton` and `.messageBar`. Only this package's own rules were scoped under `.tspdf-root`;
+  the pdf.js ones shipped globally. Because the stylesheet is injected at runtime it won every
+  cascade tie, so a host with its own `.sidebar` had it silently restyled (wrong width, white
+  background, `position: relative` + `inset-block-start`) as soon as the viewer module loaded —
+  which happens on preference selection, before any PDF is opened.
+
+  Every selector is now scoped at build time, after nesting is flattened. `:root`/`html`/`body`
+  are re-targeted to `.tspdf-root` rather than prefixed, so the custom properties the viewer's
+  descendants read still resolve. `npm run verify:package` fails the build if any selector is
+  unscoped, or prefixed more than once (which would match nothing and break the viewer's own
+  styling).
+
 ## [1.2.0] — 2026-08-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamsync-pdf-viewer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "CPAL-1.0",
   "description": "TeamSync PDF Viewer SDK — client-side PDF viewing, annotation, search, redaction and watermarking for React.",
   "type": "module",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -47,7 +47,40 @@ if (!lib.startsWith('"use client";')) fail('library bundle is missing the "use c
 const sizeMB = statSync(pkg.module).size / (1024 * 1024);
 if (sizeMB > 1.5) fail(`library bundle is ${sizeMB.toFixed(2)} MB — dependencies are no longer externalized`);
 
-// 4. publint + arethetypeswrong on the packed tarball.
+// 4. Every selector in the stylesheet must be scoped under `.tspdf-root`.
+//    dist/style.css bundles pdfjs-dist/web/pdf_viewer.css, which contains bare generic class names
+//    (.sidebar, .dialog, .toggle-button, .closeButton, .messageBar). Shipping those unscoped
+//    restyles the host application the moment the stylesheet loads — 1.2.0 broke TeamSync's
+//    sidebar exactly this way. Scoping happens in vite.config.ts; this asserts the OUTPUT.
+{
+  const { default: postcss } = await import('postcss');
+  const cssFile = pkg.exports['./style.css'];
+  const root = postcss.parse(readFileSync(cssFile, 'utf8'));
+  const SKIP = /^(keyframes|font-face|property|counter-style|page)$/i;
+  const unscoped = [];
+  const doubled = [];
+  root.walkRules((rule) => {
+    if (rule.parent && rule.parent.type === 'rule') return;
+    for (let p = rule.parent; p; p = p.parent) {
+      if (p.type === 'atrule' && SKIP.test(String(p.name).replace(/^-\w+-/, ''))) return;
+    }
+    for (const sel of rule.selectors) {
+      const n = (sel.match(/\.tspdf-root/g) || []).length;
+      if (n === 0) unscoped.push(sel);
+      if (n > 1) doubled.push(sel);
+    }
+  });
+  if (unscoped.length) {
+    fail(`${unscoped.length} selector(s) in ${cssFile} are not scoped under .tspdf-root and will leak into host apps, e.g.: ${unscoped.slice(0, 5).join(' | ')}`);
+  }
+  // A doubly-prefixed selector matches nothing, so the viewer's own styling silently breaks.
+  if (doubled.length) {
+    fail(`${doubled.length} selector(s) in ${cssFile} are prefixed more than once and match nothing, e.g.: ${doubled.slice(0, 5).join(' | ')}`);
+  }
+  console.log(`✓ CSS scoping: all ${root.nodes.length} top-level nodes scoped under .tspdf-root`);
+}
+
+// 5. publint + arethetypeswrong on the packed tarball.
 execSync('npx publint --strict', { stdio: 'inherit' });
 // - ./style.css is a stylesheet entrypoint: it has no types by design.
 // - internal-resolution-error: the emitted .d.ts files use extension-less relative imports, which

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,11 +7,74 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'node:path';
 
+import postcss from 'postcss';
+
+/**
+ * Prefix every selector in the EMITTED stylesheet with `.tspdf-root`.
+ *
+ * dist/style.css bundles `pdfjs-dist/web/pdf_viewer.css` (~900 selectors) written for pdf.js's own
+ * standalone viewer, including bare generic class names — `.sidebar`, `.dialog`, `.toggle-button`,
+ * `.closeButton`, `.messageBar`. Those collide with host application markup: a host with its own
+ * `.sidebar` gets it restyled the moment this stylesheet loads, because the library CSS is injected
+ * at runtime and so wins the cascade at equal specificity.
+ *
+ * This runs at `generateBundle`, i.e. AFTER nesting has been flattened. Rewriting selectors earlier
+ * (via css.postcss) prefixes a nested rule as well as its parent and yields dead selectors like
+ * `.tspdf-root .annotationLayer .tspdf-root .textWidgetAnnotation`.
+ */
+function scopeEmittedCss() {
+  const SKIP_ATRULES = /^(keyframes|font-face|property|counter-style|page)$/i;
+  const scope = (css: string): string => {
+    const root = postcss.parse(css);
+    root.walkRules((rule: any) => {
+      if (rule.parent && rule.parent.type === 'rule') return; // covered by the parent selector
+      for (let p = rule.parent; p; p = p.parent) {
+        if (p.type === 'atrule' && SKIP_ATRULES.test(String(p.name).replace(/^-\w+-/, ''))) return;
+      }
+      rule.selectors = rule.selectors.map((sel: string) => {
+        const t = sel.trim();
+        if (!t || t.includes('.tspdf-root')) return t;
+        // :root/html/body hold custom properties the viewer's descendants read, and the viewer
+        // root is their ancestor — re-target rather than prefix (`.tspdf-root :root` is dead).
+        if (/^(:root|html|body)$/i.test(t)) return '.tspdf-root';
+        if (/^(html|body)\b/i.test(t)) return t.replace(/^(html|body)\b/i, '.tspdf-root');
+        return `.tspdf-root ${t}`;
+      });
+    });
+    return root.toString();
+  };
+  return {
+    name: 'tspdf-scope-emitted-css',
+    // `post` matters: Vite's own CSS plugin emits style.css during generateBundle, so an
+    // unordered hook runs before the asset exists and silently does nothing.
+    enforce: 'post' as const,
+    generateBundle: {
+      order: 'post' as const,
+      handler(_options: unknown, bundle: Record<string, any>) {
+        let touched = 0;
+        for (const [file, asset] of Object.entries(bundle)) {
+          if (asset.type === 'asset' && file.endsWith('.css')) {
+            asset.source = scope(String(asset.source));
+            touched++;
+          }
+        }
+        if (touched === 0) {
+          throw new Error(
+            'tspdf-scope-emitted-css found no CSS asset to scope — the library CSS would ship ' +
+              'unscoped and restyle host applications (see the .sidebar collision in 1.2.0).'
+          );
+        }
+      },
+    },
+  };
+}
+
 export default defineConfig({
   // The demo assets under public/ belong to the application build only.
   publicDir: false,
   plugins: [
     react(),
+    scopeEmittedCss(),
     dts({
       // The root tsconfig.json is a solution-style file with `files: []`; pointing the plugin at it
       // emitted a 10-byte `export {}` stub. Use the app config and drop the demo entry.


### PR DESCRIPTION
## The bug

Selecting this viewer in TeamSync's Settings visibly broke the app's navigation rail — **before opening any PDF**.

`dist/style.css` bundles `pdfjs-dist/web/pdf_viewer.css`: ~900 selectors written for pdf.js's own standalone viewer, including bare generic class names — `.sidebar`, `.dialog`, `.toggle-button`, `.closeButton`, `.messageBar`. In 1.1.0 I scoped **this package's own** rules under `.tspdf-root` but not the bundled pdf.js ones, so those shipped globally.

Since the stylesheet is injected at runtime, it wins every cascade tie at equal specificity:

| | `width` | `background-color` | extras |
|---|---|---|---|
| host `.sidebar` | `280px` | `var(--bg-secondary)` | flex column, `border-right` |
| pdf.js `.sidebar` | `239px` | `#fff` | `border-radius`, `box-shadow`, `position:relative`, `inset-block-start: calc(100% + …)` |

It triggers on mere *selection* because the preference registry dynamically imports the viewer module, which imports the CSS.

## The fix

Scope every selector at build time, in `generateBundle` — i.e. **after nesting is flattened**.

Doing it earlier (via `css.postcss`) prefixes a nested rule *and* its parent, producing dead selectors like `.tspdf-root .annotationLayer .tspdf-root .textWidgetAnnotation` — I hit exactly that and it silently breaks the viewer's own annotation layer. `:root`/`html`/`body` are re-targeted to `.tspdf-root` rather than prefixed, so the custom properties descendants read still resolve.

The hook is `enforce: 'post'` + `order: 'post'`: Vite emits `style.css` in its own `generateBundle`, so an unordered hook runs before the asset exists and silently no-ops. It throws if it finds no CSS asset, rather than shipping unscoped CSS again.

## Guard

`verify:package` now fails on **any** unscoped selector, and on any selector prefixed more than once. Verified non-vacuous — unscoping a single selector produces:

```
❌ 1 selector(s) in ./dist/style.css are not scoped under .tspdf-root ... e.g.: .textLayer
```

## Verification

`lint` 0 errors · `typecheck` clean · `vitest` 34 passed · `build` · `verify:package` → `✓ CSS scoping: all 819 top-level nodes scoped under .tspdf-root`. Viewer styles confirmed intact (`.tspdf-root .textLayer` and friends still present).

Marked `fix!` because any consumer relying on these globals leaking would see a change — that behaviour was the bug.